### PR TITLE
change export format from '_' to '.'

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,7 +78,7 @@ export default {
 			}
 
 			const finalContents = LyricManager.generateTranslatedContents(this.fileContents, this.dataStore.translatedLyrics);
-			const fileName = this.dataStore.file.name.replace(/\.[^/.]+$/, "") + "_" + this.dataStore.selectedLang + ".lrc";
+			const fileName = this.dataStore.file.name.replace(/\.[^/.]+$/, "") + "." + this.dataStore.selectedLang + ".lrc";
 			this.prepareDownload(fileName, finalContents);
 		},
 		prepareDownload(fileName, fileContents) {


### PR DESCRIPTION
Maybe using `music.zh_CN.lrc` instead of `music_zh_CN.lrc` is a better choice for general music players to detect the translated subtitles.

Resolves #18